### PR TITLE
Add regulation

### DIFF
--- a/lib/butterfli-instagram.rb
+++ b/lib/butterfli-instagram.rb
@@ -10,15 +10,20 @@ require 'instagram'
 # Load files
 require 'butterfli/instagram'
 require 'butterfli/instagram/configuration'
-require 'butterfli/instagram/configuration/provider'
 
 require 'butterfli/instagram/data'
 require 'butterfli/instagram/data/media_object'
+require 'butterfli/instagram/data/cache'
+require 'butterfli/instagram/data/cache/query'
 
 require 'butterfli/instagram/jobs/job'
 require 'butterfli/instagram/jobs/geography_recent_media'
 require 'butterfli/instagram/jobs/location_recent_media'
 require 'butterfli/instagram/jobs/tag_recent_media'
+
+require 'butterfli/instagram/regulation'
+require 'butterfli/instagram/regulation/job_throttle'
+require 'butterfli/instagram/regulation/jobs_policy'
 
 require 'butterfli/instagram/tasks'
 

--- a/lib/butterfli/instagram/configuration.rb
+++ b/lib/butterfli/instagram/configuration.rb
@@ -1,2 +1,5 @@
 module Butterfli::Instagram::Configuration
 end
+
+require 'butterfli/instagram/configuration/provider'
+require 'butterfli/instagram/configuration/regulation'

--- a/lib/butterfli/instagram/configuration/provider.rb
+++ b/lib/butterfli/instagram/configuration/provider.rb
@@ -8,6 +8,9 @@ class Butterfli::Instagram::Configuration::Provider < Butterfli::Configuration::
       ::Instagram.client
     end
   end
+  def policies_class
+    Butterfli::Instagram::Configuration::Regulation::Policies
+  end
 end
 
 # Add it to the known providers list...

--- a/lib/butterfli/instagram/configuration/regulation.rb
+++ b/lib/butterfli/instagram/configuration/regulation.rb
@@ -1,0 +1,11 @@
+module Butterfli::Instagram::Configuration::Regulation
+end
+
+require 'butterfli/instagram/configuration/regulation/throttles'
+require 'butterfli/instagram/configuration/regulation/job_throttle'
+require 'butterfli/instagram/configuration/regulation/geography_job_throttle'
+require 'butterfli/instagram/configuration/regulation/location_job_throttle'
+require 'butterfli/instagram/configuration/regulation/tag_job_throttle'
+
+require 'butterfli/instagram/configuration/regulation/policies'
+require 'butterfli/instagram/configuration/regulation/jobs_policy'

--- a/lib/butterfli/instagram/configuration/regulation/geography_job_throttle.rb
+++ b/lib/butterfli/instagram/configuration/regulation/geography_job_throttle.rb
@@ -1,0 +1,13 @@
+module Butterfli::Instagram::Configuration::Regulation
+  class GeographyJobThrottle < Butterfli::Instagram::Configuration::Regulation::JobThrottle
+    def self.job_class
+      Butterfli::Instagram::Jobs::GeographyRecentMedia
+    end
+    def last_time_key
+      Butterfli::Instagram::Data::Cache.for.subscription(:geography, self.args[:obj_id]).field(:last_time_queued).key
+    end
+  end
+end
+
+# Add it to the known throttles list...
+Butterfli::Instagram::Configuration::Regulation::Throttles.register_throttle(:geography, Butterfli::Instagram::Configuration::Regulation::GeographyJobThrottle)

--- a/lib/butterfli/instagram/configuration/regulation/job_throttle.rb
+++ b/lib/butterfli/instagram/configuration/regulation/job_throttle.rb
@@ -1,0 +1,20 @@
+module Butterfli::Instagram::Configuration::Regulation
+  class JobThrottle < Butterfli::Configuration::Regulation::Throttle
+    attr_accessor :type, :args
+
+    def initialize
+      self.args ||= {}
+    end
+    def instance_class
+      Butterfli::Instagram::Regulation::JobThrottle
+    end
+    def options
+      super.merge(type: self.class.job_class,
+                  args: self.args || {},
+                  last_time_key: self.last_time_key)
+    end
+    def matching(args = {})
+      self.args = args
+    end
+  end
+end

--- a/lib/butterfli/instagram/configuration/regulation/jobs_policy.rb
+++ b/lib/butterfli/instagram/configuration/regulation/jobs_policy.rb
@@ -1,0 +1,13 @@
+module Butterfli::Instagram::Configuration::Regulation
+  class JobsPolicy < Butterfli::Configuration::Regulation::Policy
+    def instance_class
+      Butterfli::Instagram::Regulation::JobsPolicy
+    end
+    def throttles_class
+      Butterfli::Instagram::Configuration::Regulation::Throttles
+    end
+  end
+end
+
+# Add it to the known policies list...
+Butterfli::Instagram::Configuration::Regulation::Policies.register_policy(:jobs, Butterfli::Instagram::Configuration::Regulation::JobsPolicy)

--- a/lib/butterfli/instagram/configuration/regulation/location_job_throttle.rb
+++ b/lib/butterfli/instagram/configuration/regulation/location_job_throttle.rb
@@ -1,0 +1,13 @@
+module Butterfli::Instagram::Configuration::Regulation
+  class LocationJobThrottle < Butterfli::Instagram::Configuration::Regulation::JobThrottle
+    def self.job_class
+      Butterfli::Instagram::Jobs::LocationRecentMedia
+    end
+    def last_time_key
+      Butterfli::Instagram::Data::Cache.for.subscription(:location, self.args[:obj_id]).field(:last_time_queued).key
+    end
+  end
+end
+
+# Add it to the known throttles list...
+Butterfli::Instagram::Configuration::Regulation::Throttles.register_throttle(:location, Butterfli::Instagram::Configuration::Regulation::LocationJobThrottle)

--- a/lib/butterfli/instagram/configuration/regulation/policies.rb
+++ b/lib/butterfli/instagram/configuration/regulation/policies.rb
@@ -1,0 +1,18 @@
+module Butterfli::Instagram::Configuration::Regulation
+  module Policies
+    def self.known_policies
+      @known_policies ||= {}
+    end
+    def self.register_policy(name, klass)
+      self.known_policies[name.to_sym] = klass
+    end
+    def self.instantiate_policy(name, options = {})
+      policy = self.known_policies[name.to_sym]
+      if policy
+        policy.new
+      else
+        raise "Unknown policy: #{name}!"
+      end
+    end
+  end
+end

--- a/lib/butterfli/instagram/configuration/regulation/tag_job_throttle.rb
+++ b/lib/butterfli/instagram/configuration/regulation/tag_job_throttle.rb
@@ -1,0 +1,13 @@
+module Butterfli::Instagram::Configuration::Regulation
+  class TagJobThrottle < Butterfli::Instagram::Configuration::Regulation::JobThrottle
+    def self.job_class
+      Butterfli::Instagram::Jobs::TagRecentMedia
+    end
+    def last_time_key
+      Butterfli::Instagram::Data::Cache.for.subscription(:tag, self.args[:obj_id]).field(:last_time_queued).key
+    end
+  end
+end
+
+# Add it to the known throttles list...
+Butterfli::Instagram::Configuration::Regulation::Throttles.register_throttle(:tag, Butterfli::Instagram::Configuration::Regulation::TagJobThrottle)

--- a/lib/butterfli/instagram/configuration/regulation/throttles.rb
+++ b/lib/butterfli/instagram/configuration/regulation/throttles.rb
@@ -1,0 +1,18 @@
+module Butterfli::Instagram::Configuration::Regulation
+  module Throttles
+    def self.known_throttles
+      @known_throttles ||= {}
+    end
+    def self.register_throttle(name, klass)
+      self.known_throttles[name.to_sym] = klass
+    end
+    def self.instantiate_throttle(name, options = {})
+      throttle = self.known_throttles[name.to_sym]
+      if throttle
+        throttle.new
+      else
+        raise "Unknown throttle: #{name}!"
+      end
+    end
+  end
+end

--- a/lib/butterfli/instagram/data/cache.rb
+++ b/lib/butterfli/instagram/data/cache.rb
@@ -1,0 +1,7 @@
+module Butterfli::Instagram::Data
+  module Cache
+    def self.for
+      Butterfli::Instagram::Data::Cache::Query.new
+    end
+  end
+end

--- a/lib/butterfli/instagram/data/cache/query.rb
+++ b/lib/butterfli/instagram/data/cache/query.rb
@@ -1,0 +1,34 @@
+module Butterfli::Instagram::Data::Cache
+  class Query
+    attr_accessor :obj_type, :obj_subtype, :obj_id, :field_name
+
+    def key
+      key = "Instagram"
+      [self.obj_type, self.obj_subtype, self.obj_id, self.field_name].each do |dimension|
+        key += ":#{dimension}" if !dimension.nil?
+      end
+      key
+    end
+    def read
+      Butterfli.cache.read(self.key)
+    end
+    def write(value)
+      Butterfli.cache.write(self.key, value)
+    end
+    def subscription(subtype, id)
+      self.obj_type = "Subscription"
+      self.obj_subtype = { geography: 'Geography', location: 'Location', tag: 'Tag' }[subtype]
+      self.obj_id = id
+      self
+    end
+    def field(name)
+      self.field_name = { min_obj_id: 'MinObjectId',
+                          max_obj_id: 'MaxObjectId',
+                          min_tag_id: 'MinTagId',
+                          max_tag_id: 'MaxTagId',
+                          last_time_ran: 'LastTimeRan',
+                          last_time_queued: 'LastTimeQueued' }[name]
+      self
+    end
+  end
+end

--- a/lib/butterfli/instagram/jobs/location_recent_media.rb
+++ b/lib/butterfli/instagram/jobs/location_recent_media.rb
@@ -5,7 +5,7 @@ module Butterfli::Instagram::Jobs
     attr_accessor :max_obj_id
 
     def hash
-      [self.class.name, self.args[:obj_id], self.args[:min_id]]
+      [self.class.name, self.args[:obj_id]].hash
     end
 
     def get_stories
@@ -22,9 +22,11 @@ module Butterfli::Instagram::Jobs
       stories
     end
     after_work do |job, stories|
+      Butterfli::Instagram::Data::Cache.for.subscription(:location, job.args[:obj_id]).field(:last_time_ran).write(Time.now)
+    end
+    after_work do |job, stories|
       if !job.args[:skip_pagination_update] && !job.max_obj_id.nil?
-        # TODO: Create intermediate cache layer to centralize cache key management
-        Butterfli.cache.write("Instagram:Subscription:Location:#{job.args[:obj_id]}:MaxObjectId", job.max_obj_id)
+        Butterfli::Instagram::Data::Cache.for.subscription(:location, job.args[:obj_id]).field(:max_obj_id).write(job.max_obj_id)
       end
     end
   end

--- a/lib/butterfli/instagram/jobs/tag_recent_media.rb
+++ b/lib/butterfli/instagram/jobs/tag_recent_media.rb
@@ -2,29 +2,33 @@ module Butterfli::Instagram::Jobs
   class TagRecentMedia < Butterfli::Jobs::StoryJob
     include Butterfli::Instagram::Job
 
-    attr_accessor :max_obj_id
+    attr_accessor :max_obj_id, :min_tag_id, :max_tag_id
 
     def hash
-      [self.class.name, self.args[:obj_id], self.args[:min_id]]
+      [self.class.name, self.args[:obj_id]].hash
     end
 
     def get_stories
       raise ArgumentError, "Missing tag ID to fetch!" if args[:obj_id].nil?
-      media_objects = self.client.tag_recent_media(args[:obj_id], min_id: args[:min_id])
-      media_objects = media_objects.uniq { |item| item['id'] }
+      result = self.client.tag_recent_media(args[:obj_id], min_tag_id: args[:min_tag_id])
+      self.min_tag_id = result.pagination.min_tag_id
+      self.max_tag_id = result.pagination.next_max_tag_id
+      media_objects = result.uniq { |item| item['id'] }
 
       stories = []
       if !media_objects.empty?
         stories = self.convert_media_objects_to_stories(media_objects)
-        # Store the maximum seen object, for pagination purposes
         self.max_obj_id = media_objects.collect(&:id).max
       end
       stories
     end
     after_work do |job, stories|
-      if !job.args[:skip_pagination_update] && !job.max_obj_id.nil?
-        # TODO: Create intermediate cache layer to centralize cache key management
-        Butterfli.cache.write("Instagram:Subscription:Tag:#{job.args[:obj_id]}:MaxObjectId", job.max_obj_id)
+      Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:last_time_ran).write(Time.now)
+    end
+    after_work do |job, stories|
+      if !job.args[:skip_pagination_update]
+        Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:min_tag_id).write(job.min_tag_id) if !job.min_tag_id.nil?
+        Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:max_tag_id).write(job.max_tag_id) if !job.max_tag_id.nil?
       end
     end
   end

--- a/lib/butterfli/instagram/regulation.rb
+++ b/lib/butterfli/instagram/regulation.rb
@@ -1,0 +1,16 @@
+module Butterfli::Instagram::Regulation
+  def self.policies=(policies)
+    @policies = policies
+  end
+  def self.policies(name = nil)
+    if @policies.nil?
+      @policies = {}
+      if (provider = Butterfli.configuration.providers(:instagram)) && (provider.policies)
+        provider.policies.collect do |policy_name, policy_config|
+          @policies[policy_name] = policy_config.instantiate
+        end
+      end
+    end
+    name.nil? ? @policies : @policies[name]
+  end
+end

--- a/lib/butterfli/instagram/regulation/job_throttle.rb
+++ b/lib/butterfli/instagram/regulation/job_throttle.rb
@@ -1,0 +1,21 @@
+module Butterfli::Instagram::Regulation
+  class JobThrottle < Butterfli::Regulation::Throttle
+    include Butterfli::Regulation::Matchers::Type
+    attr_accessor :last_time_key, :args
+
+    def initialize(options = {})
+      super
+      self.type = options[:type]
+      self.last_time_key = options[:last_time_key]
+      self.args = (options[:args] || {})
+    end
+    fact :last_time do |rule, item|
+      Butterfli.cache.read(rule.last_time_key)
+    end
+    applies_if do |rule, item|
+      rule.args.inject(true) do |result, (field, value)|
+        result = result && item.args[field] == value
+      end
+    end
+  end
+end

--- a/lib/butterfli/instagram/regulation/jobs_policy.rb
+++ b/lib/butterfli/instagram/regulation/jobs_policy.rb
@@ -1,0 +1,4 @@
+module Butterfli::Instagram::Regulation
+  class JobsPolicy < Butterfli::Regulation::Policy
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/geography_job_throttle_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/geography_job_throttle_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::GeographyJobThrottle do
+  let(:args) { { obj_id: 1 } }
+  let(:max) { 400 }
+  let(:interval) { 3600 }
+  before(:each) do
+    configure_for_instagram do |provider|
+      provider.policy :jobs do |jobs|
+        jobs.throttle :geography do |t|
+          t.matching args
+          t.limit max
+          t.per_seconds interval
+        end
+      end
+    end
+  end
+  subject { Butterfli.configuration.providers(:instagram).policies(:jobs).rules }
+  it do
+    expect(subject).to_not be_empty
+    expect(subject.first).to be_a_kind_of(Butterfli::Instagram::Configuration::Regulation::GeographyJobThrottle)
+    expect(subject.first.max).to eq(max)
+    expect(subject.first.interval).to eq(interval)
+    expect(subject.first.args).to eq(args)
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/job_throttle_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/job_throttle_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::JobThrottle do
+  let(:job_throttle_config_class) do
+    stub_const 'TestJobThrottleConfig', Class.new(Butterfli::Instagram::Configuration::Regulation::JobThrottle)
+    TestJobThrottleConfig.class_eval do
+      def last_time_key; nil end
+      def self.job_class; nil end
+    end
+    TestJobThrottleConfig
+  end
+  let(:job_throttle_config) { job_throttle_config_class.new }
+
+  context "when initialized" do
+    subject { job_throttle_config }
+    it { expect(subject.args).to be_empty }
+  end
+  describe "#matching" do
+    subject { job_throttle_config.matching args }
+    context "when provided a list of arguments" do
+      let(:args) { double('args') }
+      it { subject; expect(job_throttle_config.args).to eq(args) }
+    end
+  end
+  describe "#instantiate" do
+    subject { job_throttle_config.instantiate }
+    let(:type) { double('type') }
+    let(:args) { double('args') }
+    let(:last_time_key) { double('last_time_key') }
+    before(:each) do
+      job_throttle_config.matching args
+      allow(job_throttle_config).to receive(:last_time_key).and_return(last_time_key)
+      allow(job_throttle_config.class).to receive(:job_class).and_return(type)
+    end
+    it { expect(subject).to be_a_kind_of(Butterfli::Instagram::Regulation::JobThrottle) }
+    it { expect(subject.type).to eq(type) }
+    it { expect(subject.args).to eq(args) }
+    it { expect(subject.last_time_key).to eq(last_time_key) }
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/jobs_policy_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/jobs_policy_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::JobsPolicy do
+  let(:args) { { obj_id: 1 } }
+  let(:max) { 400 }
+  let(:interval) { 3600 }
+  before(:each) do
+    configure_for_instagram do |provider|
+      provider.policy :jobs do nil end
+    end
+  end
+  subject { Butterfli.configuration.providers(:instagram).policies }
+  it do
+    expect(subject).to_not be_empty
+    expect(subject.first).to include(:jobs, Butterfli::Instagram::Configuration::Regulation::JobsPolicy)
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/location_job_throttle_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/location_job_throttle_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::LocationJobThrottle do
+  let(:args) { { obj_id: 1 } }
+  let(:max) { 400 }
+  let(:interval) { 3600 }
+  before(:each) do
+    configure_for_instagram do |provider|
+      provider.policy :jobs do |jobs|
+        jobs.throttle :location do |t|
+          t.matching args
+          t.limit max
+          t.per_seconds interval
+        end
+      end
+    end
+  end
+  subject { Butterfli.configuration.providers(:instagram).policies(:jobs).rules }
+  it do
+    expect(subject).to_not be_empty
+    expect(subject.first).to be_a_kind_of(Butterfli::Instagram::Configuration::Regulation::LocationJobThrottle)
+    expect(subject.first.max).to eq(max)
+    expect(subject.first.interval).to eq(interval)
+    expect(subject.first.args).to eq(args)
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/policies_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/policies_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::Policies do
+  subject { Butterfli::Instagram::Configuration::Regulation::Policies }
+
+  describe "#known_policies" do
+    subject { super().known_policies }
+
+    context "when invoked with no parameters" do
+      it { expect(subject).to_not be_nil }
+    end
+  end
+
+  describe "#register_policy" do
+    subject { super().register_policy(policy_name, policy_class) }
+
+    # Create fake policy to drive tests
+    let(:policy_name) { :test_policy }
+    let(:policy_class) do
+      stub_const 'TestPolicy', Class.new(Butterfli::Configuration::Regulation::Policy)
+      TestPolicy
+    end
+
+    context "when invoked with a policy name and class" do
+      it do
+        expect(subject).to eq(policy_class)
+        expect(Butterfli::Instagram::Configuration::Regulation::Policies.known_policies).to include(policy_name)
+      end
+    end
+  end
+
+  describe "#instantiate_policy" do
+    subject { super().instantiate_policy(policy_name) }
+
+    # Create fake policy to drive tests
+    let(:policy_class) do
+      stub_const 'TestPolicy', Class.new(Butterfli::Configuration::Regulation::Policy)
+      TestPolicy
+    end
+    before { Butterfli::Instagram::Configuration::Regulation::Policies.register_policy(:test_policy, policy_class) }
+
+    context "when invoked with a known policy" do
+      context "(as a Symbol)" do
+        let(:policy_name) { :test_policy }
+        it { expect(subject).to be_a_kind_of(policy_class) }
+      end
+      context "(as a String)" do
+        let(:policy_name) { "test_policy" }
+        it { expect(subject).to be_a_kind_of(policy_class) }
+      end
+    end
+    context "when invoked with an unknown policy" do
+      let(:policy_name) { :unknown_policy }
+      it do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/tag_job_throttle_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/tag_job_throttle_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::TagJobThrottle do
+  let(:args) { { obj_id: 1 } }
+  let(:max) { 400 }
+  let(:interval) { 3600 }
+  before(:each) do
+    configure_for_instagram do |provider|
+      provider.policy :jobs do |jobs|
+        jobs.throttle :tag do |t|
+          t.matching args
+          t.limit max
+          t.per_seconds interval
+        end
+      end
+    end
+  end
+  subject { Butterfli.configuration.providers(:instagram).policies(:jobs).rules }
+  it do
+    expect(subject).to_not be_empty
+    expect(subject.first).to be_a_kind_of(Butterfli::Instagram::Configuration::Regulation::TagJobThrottle)
+    expect(subject.first.max).to eq(max)
+    expect(subject.first.interval).to eq(interval)
+    expect(subject.first.args).to eq(args)
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation/throttles_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation/throttles_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation::Throttles do
+  subject { Butterfli::Instagram::Configuration::Regulation::Throttles }
+
+  describe "#known_throttles" do
+    subject { super().known_throttles }
+
+    context "when invoked with no parameters" do
+      it { expect(subject).to_not be_nil }
+    end
+  end
+
+  describe "#register_throttle" do
+    subject { super().register_throttle(throttle_name, throttle_class) }
+
+    # Create fake throttle to drive tests
+    let(:throttle_name) { :test_throttle }
+    let(:throttle_class) do
+      stub_const 'TestThrottle', Class.new(Butterfli::Configuration::Regulation::Throttle)
+      TestThrottle
+    end
+
+    context "when invoked with a throttle name and class" do
+      it do
+        expect(subject).to eq(throttle_class)
+        expect(Butterfli::Instagram::Configuration::Regulation::Throttles.known_throttles).to include(throttle_name)
+      end
+    end
+  end
+
+  describe "#instantiate_throttle" do
+    subject { super().instantiate_throttle(throttle_name) }
+
+    # Create fake throttle to drive tests
+    let(:throttle_class) do
+      stub_const 'TestThrottle', Class.new(Butterfli::Configuration::Regulation::Throttle)
+      TestThrottle
+    end
+    before { Butterfli::Instagram::Configuration::Regulation::Throttles.register_throttle(:test_throttle, throttle_class) }
+
+    context "when invoked with a known throttle" do
+      context "(as a Symbol)" do
+        let(:throttle_name) { :test_throttle }
+        it { expect(subject).to be_a_kind_of(throttle_class) }
+      end
+      context "(as a String)" do
+        let(:throttle_name) { "test_throttle" }
+        it { expect(subject).to be_a_kind_of(throttle_class) }
+      end
+    end
+    context "when invoked with an unknown throttle" do
+      let(:throttle_name) { :unknown_throttle }
+      it do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/butterfli/instagram/configuration/regulation_spec.rb
+++ b/spec/butterfli/instagram/configuration/regulation_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Configuration::Regulation do
+  # Regulation does not define any behavior
+end

--- a/spec/butterfli/instagram/data/cache/query_spec.rb
+++ b/spec/butterfli/instagram/data/cache/query_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Data::Cache::Query do
+  let(:query) { Butterfli::Instagram::Data::Cache::Query.new }
+  describe "#subscription" do
+    subject { query.subscription(subtype, id) }
+    context "when given a subtype and id" do
+      let(:subtype) { :geography }
+      let(:id) { 123 }
+      it { expect(subject.obj_type).to eq('Subscription') }
+      it { expect(subject.obj_subtype).to eq('Geography') }
+      it { expect(subject.obj_id).to eq(id) }
+    end
+  end
+  describe "#field" do
+    subject { query.field(name) }
+    context "when given a name" do
+      let(:name) { :min_tag_id }
+      it { expect(subject.field_name).to eq('MinTagId') }
+    end
+  end
+  context "when chaining dimensions" do
+    subject { query.subscription(subtype, id).field(name) }
+    let(:subtype) { :geography }
+    let(:id) { 123 }
+    let(:name) { :min_tag_id }
+    it { expect(subject.obj_type).to eq('Subscription') }
+    it { expect(subject.obj_subtype).to eq('Geography') }
+    it { expect(subject.obj_id).to eq(id) }
+    it { expect(subject.field_name).to eq('MinTagId') }
+  end
+
+  describe "#key" do
+    subject { query.key }
+    context "when no dimensions have been set" do
+      it { expect(subject).to eq('Instagram') }
+    end
+    context "after multiple dimensions have been set" do
+      let(:subtype) { :geography }
+      let(:id) { 123 }
+      let(:name) { :min_tag_id }
+      before(:each) { query.subscription(subtype, id).field(name) }
+      it { expect(subject).to eq("Instagram:Subscription:Geography:#{id}:MinTagId") }
+    end
+  end
+  describe "#read" do
+    subject { query.read }
+    let(:cache) { double('cache') }
+    before(:each) do
+      allow(cache).to receive(:read).with(String).and_return(Time.now)
+      Butterfli.cache = cache
+    end
+    after(:each) { Butterfli.cache = nil }
+    it do
+      expect(cache).to receive(:read).with(query.key)
+      expect(subject).to be_a_kind_of(Time)
+    end
+  end
+  describe "#write" do
+    subject { query.write(value) }
+    context "when given a value" do
+      let(:value) { Time.now }
+      let(:cache) { double('cache') }
+      before(:each) do
+        allow(cache).to receive(:write).with(String, Object)
+        Butterfli.cache = cache
+      end
+      after(:each) { Butterfli.cache = nil }
+      it { expect(cache).to receive(:write).with(query.key, value); subject }
+    end
+  end
+end

--- a/spec/butterfli/instagram/data/cache_spec.rb
+++ b/spec/butterfli/instagram/data/cache_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Data::Cache do
+  describe "#for" do
+    subject { Butterfli::Instagram::Data::Cache.for }
+    it { expect(subject).to be_a_kind_of(Butterfli::Instagram::Data::Cache::Query) }
+  end
+end

--- a/spec/butterfli/instagram/jobs/location_recent_media_spec.rb
+++ b/spec/butterfli/instagram/jobs/location_recent_media_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.shared_examples_for "a request for stories" do
+RSpec.shared_examples_for "a request for stories (location)" do
   context "that retrieves no media objects" do
     let(:media_objects) do
       read_media_objects_fixture('media_objects/empty')
@@ -60,7 +60,7 @@ describe Butterfli::Instagram::Jobs::LocationRecentMedia do
         end
         it do
           expect(job).to_not eq(other_job)
-          expect(job.eql?(other_job)).to be false
+          expect(job.eql?(other_job)).to be true # Equivalent because we don't care if min_id is the same
         end
       end
     end
@@ -76,11 +76,11 @@ describe Butterfli::Instagram::Jobs::LocationRecentMedia do
       before(:each) do
         allow(job.client).to receive(:location_recent_media).with(obj_id, Hash) { media_objects }
       end
-      it_behaves_like "a request for stories"
+      it_behaves_like "a request for stories (location)"
       context "and a min_id" do
         let(:min_id) { "2" }
         let(:options) { { obj_id: obj_id, min_id: min_id } }
-        it_behaves_like "a request for stories"
+        it_behaves_like "a request for stories (location)"
       end
     end
   end
@@ -94,12 +94,19 @@ describe Butterfli::Instagram::Jobs::LocationRecentMedia do
     end
     context "when it doesn't retrieve a story" do
       let(:stories) { [] }
-      it { expect(cache).to_not receive(:write); subject }
+      it do
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:location, job.args[:obj_id]).field(:last_time_ran).key, Time)
+        subject
+      end
     end
     context "when it retrieves a story" do
       let(:story) { s = Butterfli::Data::Story.new; s.source.id = 1; s }
       let(:stories) { [story] }
-      it { expect(cache).to receive(:write).with(String, story.source.id); subject }
+      it do
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:location, job.args[:obj_id]).field(:last_time_ran).key, Time)
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:location, job.args[:obj_id]).field(:max_obj_id).key, story.source.id)
+        subject
+      end
     end
   end
 end

--- a/spec/butterfli/instagram/jobs/tag_recent_media_spec.rb
+++ b/spec/butterfli/instagram/jobs/tag_recent_media_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.shared_examples_for "a request for stories" do
+RSpec.shared_examples_for "a request for stories (tag)" do
   context "that retrieves no media objects" do
     let(:media_objects) do
       read_media_objects_fixture('media_objects/empty')
@@ -27,6 +27,20 @@ describe Butterfli::Instagram::Jobs::TagRecentMedia do
   let(:options) { { } }
   let(:job) { Butterfli::Instagram::Jobs::TagRecentMedia.new(options) }
 
+  let(:pagination_extension) do
+    stub_const 'PaginationExtension', Module.new
+    PaginationExtension.class_eval { attr_reader :pagination }
+    PaginationExtension
+  end
+  let(:min_tag_id) { "1077811283151212589" }
+  let(:next_max_tag_id) { "1077811082941429864" }
+  let(:pagination) do
+    Hashie::Mash.new({  next_max_tag_id: next_max_tag_id,
+                        next_max_id: next_max_tag_id,
+                        next_min_id: min_tag_id,
+                        min_tag_id: min_tag_id })
+  end
+
   let(:cache) { double('cache') }
   before(:each) do
     allow(cache).to receive(:write)
@@ -37,8 +51,8 @@ describe Butterfli::Instagram::Jobs::TagRecentMedia do
   context "when comparing" do
     context "to a job with identical options" do
       let(:obj_id) { "1" }
-      let(:min_id) { "2" }
-      let(:options) { { obj_id: obj_id, min_id: min_id } }
+      let(:min_tag_id) { "2" }
+      let(:options) { { obj_id: obj_id, min_tag_id: min_tag_id } }
       let(:other_job) { Butterfli::Instagram::Jobs::TagRecentMedia.new(options) }
 
       it do
@@ -54,13 +68,13 @@ describe Butterfli::Instagram::Jobs::TagRecentMedia do
           expect(job.eql?(other_job)).to be false
         end
       end
-      context "except min_id" do
+      context "except min_tag_id" do
         let(:other_job) do
-          Butterfli::Instagram::Jobs::TagRecentMedia.new(options.merge(min_id: min_id + "1"))
+          Butterfli::Instagram::Jobs::TagRecentMedia.new(options.merge(min_tag_id: min_tag_id + "1"))
         end
         it do
           expect(job).to_not eq(other_job)
-          expect(job.eql?(other_job)).to be false
+          expect(job.eql?(other_job)).to be true # Equivalent because we don't care if min_tag_id is the same
         end
       end
     end
@@ -74,32 +88,49 @@ describe Butterfli::Instagram::Jobs::TagRecentMedia do
       let(:obj_id) { "1" }
       let(:options) { { obj_id: obj_id } }
       before(:each) do
-        allow(job.client).to receive(:tag_recent_media).with(obj_id, Hash) { media_objects }
+        allow(job.client).to receive(:tag_recent_media).with(obj_id, Hash) do
+          media_objects.extend(pagination_extension)
+          media_objects.instance_variable_set("@pagination", pagination)
+          media_objects
+        end
       end
-      it_behaves_like "a request for stories"
+      it_behaves_like "a request for stories (tag)"
       context "and a min_id" do
         let(:min_id) { "2" }
         let(:options) { { obj_id: obj_id, min_id: min_id } }
-        it_behaves_like "a request for stories"
+        it_behaves_like "a request for stories (tag)"
       end
     end
   end
   describe "#work" do
     subject { job.work }
+    let(:min_tag_id) { 123 }
+    let(:max_tag_id) { 321 }
     before(:each) do
       allow(job).to receive(:get_stories) do
+        job.min_tag_id = 123
+        job.max_tag_id = 321
         job.max_obj_id = stories.last.source.id if !stories.empty?
         stories
       end
     end
     context "when it doesn't retrieve a story" do
       let(:stories) { [] }
-      it { expect(cache).to_not receive(:write); subject }
+      it do
+        expect(cache).to_not receive(:read)
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:last_time_ran).key, Time)
+        subject
+      end
     end
     context "when it retrieves a story" do
       let(:story) { s = Butterfli::Data::Story.new; s.source.id = 1; s }
       let(:stories) { [story] }
-      it { expect(cache).to receive(:write).with(String, story.source.id); subject }
+      it do
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:last_time_ran).key, Time)
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:min_tag_id).key, min_tag_id)
+        expect(cache).to receive(:write).with(Butterfli::Instagram::Data::Cache.for.subscription(:tag, job.args[:obj_id]).field(:max_tag_id).key, max_tag_id)
+        subject
+      end
     end
   end
 end

--- a/spec/butterfli/instagram/regulation/job_throttle_spec.rb
+++ b/spec/butterfli/instagram/regulation/job_throttle_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Regulation::JobThrottle do
+  let(:options) { { } }
+  let(:job_throttle) { Butterfli::Instagram::Regulation::JobThrottle.new(options) }
+  context "when initialized" do
+    subject { job_throttle }
+    context "with no options" do
+      it { expect(subject.args).to be_empty }
+    end
+    context "with a type" do
+      let(:type) { double('type') }
+      let(:options) { { type: type } }
+      it { expect(subject.type).to eq(type) }
+    end
+    context "with a last_time_key" do
+      let(:last_time_key) { double('last_time_key') }
+      let(:options) { { last_time_key: last_time_key } }
+      it { expect(subject.last_time_key).to eq(last_time_key) }
+    end
+    context "with args" do
+      let(:args) { double('args') }
+      let(:options) { { args: args } }
+      it { expect(subject.args).to eq(args) }
+    end
+  end
+  describe "last_time fact" do
+    subject { job_throttle.fact(:last_time).from(job_throttle) }
+    let(:last_time_key) { 'LastTime' }
+    let(:options) { { last_time_key: last_time_key } }
+    let(:cache) { double('cache') }
+    before(:each) do
+      allow(cache).to receive(:read).with(String).and_return(Time.now)
+      Butterfli.cache = cache
+    end
+    after(:each) { Butterfli.cache = nil }
+    it do
+      expect(cache).to receive(:read).with(last_time_key)
+      expect(subject).to be_a_kind_of(Time)
+    end
+  end
+  describe "args matcher" do
+    subject { job_throttle.applies_to?(job) }
+    let(:job) { double('job') }
+    let(:args) { { } }
+    before(:each) { allow(job).to receive(:args).and_return(args) }
+    context "when it contains no arguments" do
+      let(:options) { { type: job.class } }
+      it { expect(subject).to be true }
+    end
+    context "when it contains all matching arguments" do
+      let(:args) { { obj_id: 1 } }
+      let(:options) { { type: job.class, args: args } }
+      it { expect(subject).to be true }
+    end
+    context "when it contains at least one non-matching argument" do
+      let(:args) { { obj_id: 1, something: false } }
+      let(:options) { { type: job.class, args: args.merge(something: true) } }
+      it { expect(subject).to be false }
+    end
+  end
+end 

--- a/spec/butterfli/instagram/regulation/policy_spec.rb
+++ b/spec/butterfli/instagram/regulation/policy_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Regulation::JobsPolicy do
+  it { expect(Butterfli::Instagram::Regulation::JobsPolicy <= Butterfli::Regulation::Policy).to be true }
+end

--- a/spec/butterfli/instagram/regulation_spec.rb
+++ b/spec/butterfli/instagram/regulation_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Butterfli::Instagram::Regulation do
+  describe "#policies" do
+    subject { Butterfli::Instagram::Regulation.policies }
+    after(:each) { Butterfli::Instagram::Regulation.policies = nil }
+
+    context "when no policies have been configured" do
+      before(:each) { Butterfli::Instagram::Regulation.policies = nil }
+      it { expect(subject).to be_empty }
+    end
+    context "when a policy has been configured" do
+      let(:policy_name) { :jobs }
+      before(:each) do
+        configure_for_instagram do |provider|
+          provider.policy policy_name do |jobs|
+            jobs.throttle :geography do |t|
+              t.matching obj_id: 1
+              t.limit 1
+              t.per_seconds 1
+            end
+          end
+        end
+      end
+      it { expect(subject).to have_exactly(1).items }
+      it { expect(subject).to include(policy_name) }
+      it { expect(subject[policy_name]).to be_a_kind_of(Butterfli::Instagram::Regulation::JobsPolicy) }
+      it { expect(subject[policy_name].rules).to have_exactly(1).items }
+      it { expect(subject[policy_name].rules.first).to be_a_kind_of(Butterfli::Instagram::Regulation::JobThrottle) }
+    end
+  end
+end


### PR DESCRIPTION
`Butterfli` added the regulation which to manage objects by. This pull request implements the regulation framework to add configurable job throttles to `butterfli-instagram`. These throttles are especially useful if your application subscribes to high-volume, realtime endpoints. Given Instagram's default API limit of 5000 requests/hour, it's very easy to breach the terms of your API key when you use the most popular tags.
#### How to setup throttles within your application

To add throttles to jobs, add the following to your Butterfli configuration:

``` ruby
Butterfli.configure do |config|
  config.provider :instagram do |provider|
    provider.policy :jobs do |jobs|
      # Can be :geography, :location, or :tag
      jobs.throttle :tag do |t|
        # Only match against jobs who have these arguments
        # :obj_id is the Instagram ID of the object you're querying against
        t.matching obj_id: 'nyc'
        t.limit 400
        t.per_seconds 3600
      end
    end
  end
end
```

Then run the following check before you call `job.work`:

``` ruby
# For an example job...
job = Butterfli::Instagram::Jobs::TagRecentMedia.new(obj_id: id)
# Check if it's permitted under the policy
# It checks the Butterfli.cache for a 'last time queued' to see if it should run
if Butterfli::Instagram::Regulation.policies(:jobs).permits?(job) 
  job.work
  # Be sure to update that 'last time queued' if you do work, though.
  # Otherwise it will ignore rate limitations
  Butterfli::Instagram::Data::Cache.for.subscription(:tag, id).field(:last_time_queued).write(Time.now)
end
```

_NOTE: These throttles are not automatically enforced on jobs: calling `job.work` directly will ignore any policies. This manual check is required if you want to enforce throttles._
